### PR TITLE
fix package names and using shorter names as well

### DIFF
--- a/queue/queue.go
+++ b/queue/queue.go
@@ -1,7 +1,7 @@
 package queue
 
 import (
-	"github.com/noti5/practice/deque"
+	"golang-practice/deque"
 )
 
 type Queue struct {

--- a/stack/stack.go
+++ b/stack/stack.go
@@ -1,7 +1,7 @@
 package stack
 
 import (
-	"github.com/noti5/practice/deque"
+	"golang-practice/deque"
 )
 
 type Stack struct {

--- a/testing/testing.go
+++ b/testing/testing.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"fmt"
-	"github.com/noti5/practice/stack"
-	"github.com/noti5/practice/queue"
+	"golang-practice/stack"
+	"golang-practice/queue"
 )
 
 func main() {


### PR DESCRIPTION
@anupam-saini Change your directory structure to $GOWORKSPACE/src/golang-practice. Removed additional directory structure.